### PR TITLE
Fix minor issues with riak implementation of query.

### DIFF
--- a/.stack-lts-2.22.yaml
+++ b/.stack-lts-2.22.yaml
@@ -4,11 +4,11 @@ packages:
   - .
   - location:
       git: https://github.com/Sentenai/solr-query.git
-      commit: '099aa47'
+      commit: '3fbe94b'
     extra-dep: true
   - location:
       git: https://github.com/mitchellwrosen/riak-haskell-client
-      commit: '17a68fb'
+      commit: '3fa54e1'
     extra-dep: true
 
 extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,11 +4,11 @@ packages:
   - .
   - location:
       git: https://github.com/Sentenai/solr-query.git
-      commit: '099aa47'
+      commit: '3fbe94b'
     extra-dep: true
   - location:
       git: https://github.com/mitchellwrosen/riak-haskell-client
-      commit: '17a68fb'
+      commit: '3fa54e1'
     extra-dep: true
 
 extra-deps:


### PR DESCRIPTION
drop 2 to remove leading q= is a little hacky, but works for now.

fl arguments are just messy so we now ignore them. What's a little inefficiency between 10GbE-connected servers?